### PR TITLE
[Frontend] Change 'generate' to 'build'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
          - "10"
        install:
         - npm i --save
-        - npm run generate
+        - npm run build
        script:
          - npm run precommit
     #######################
@@ -25,9 +25,9 @@ matrix:
         - sudo cp -vRf openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit/oc /usr/bin
         - rm -rf openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit
         - npm i --save
-        - npm run generate
+        - npm run build
        script:
-         - npm run precommit
+         - npm run build
        if: branch = staging
        after_success:
          - oc login https://api.starter-us-east-2.openshift.com -u $OPENSHIFT_USER -p $OPENSHIFT_PASSWORD


### PR DESCRIPTION
This PR makes the following changes:

- Changes the `.travis.yml` file to run `npm run build` instead of `npm run generate`.

> Note: There are some ESLint warnings that are being treated as errors by Travis which should be checked out.

<img width="929" alt="image" src="https://user-images.githubusercontent.com/13445064/70920023-dcc89880-1fef-11ea-8c22-3e3293c0092c.png">
